### PR TITLE
[TGER-46] Require the new test-support as the only dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,10 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "tipoff/support": "^1.1.1"
+        "tipoff/support": "^1.2"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0",
-        "phpunit/phpunit": "^9.3",
-        "vimeo/psalm": "^4.4"
+        "tipoff/test-support": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Bump support package to 1.2
- Require the new test-support as the only dev dependency