### PR TITLE
Omnia/feature/#87 create city model migration

### DIFF
--- a/database/migrations/2021_03_02_110000_create_cities_table.php
+++ b/database/migrations/2021_03_02_110000_create_cities_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tipoff\Addresses\Models\State;
+
+class CreateCitiesTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('cities', function (Blueprint $table) {
+            $table->id();
+            $table->string('slug')->unique()->index();
+            $table->string('title')->unique();
+            $table->string('description')->nullable();
+            $table->foreignIdFor(State::class);
+            $table->timestamps();
+        });
+    }
+}

--- a/database/migrations/2021_03_02_110000_create_cities_table.php
+++ b/database/migrations/2021_03_02_110000_create_cities_table.php
@@ -11,8 +11,8 @@ class CreateCitiesTable extends Migration
     {
         Schema::create('cities', function (Blueprint $table) {
             $table->id();
-            $table->string('slug')->unique()->index();
-            $table->string('title')->unique();
+            $table->string('slug');
+            $table->string('title');
             $table->string('description')->nullable();
             $table->foreignIdFor(State::class);
             $table->timestamps();

--- a/database/migrations/2021_03_02_110000_create_cities_table.php
+++ b/database/migrations/2021_03_02_110000_create_cities_table.php
@@ -11,8 +11,8 @@ class CreateCitiesTable extends Migration
     {
         Schema::create('cities', function (Blueprint $table) {
             $table->id();
-            $table->string('slug');
-            $table->string('title');
+            $table->string('slug')->unique()->index();
+            $table->string('title')->unique();
             $table->string('description')->nullable();
             $table->foreignIdFor(State::class);
             $table->timestamps();

--- a/database/migrations/2021_03_02_110000_create_cities_table.php
+++ b/database/migrations/2021_03_02_110000_create_cities_table.php
@@ -3,7 +3,6 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Tipoff\Addresses\Models\State;
 
 class CreateCitiesTable extends Migration
 {
@@ -14,7 +13,6 @@ class CreateCitiesTable extends Migration
             $table->string('slug')->unique()->index();
             $table->string('title')->unique();
             $table->string('description')->nullable();
-            $table->foreignIdFor(State::class);
             $table->timestamps();
         });
     }

--- a/database/migrations/2021_03_04_100000_create_city_zip_code_table.php
+++ b/database/migrations/2021_03_04_100000_create_city_zip_code_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tipoff\Addresses\Models\City;
+use Tipoff\Addresses\Models\ZipCode;
+
+class CreateCityZipCodeTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('city_zip_code', function (Blueprint $table) {
+            $table->foreignIdFor(City::class);
+            $table->foreignIdFor(ZipCode::class);
+            $table->boolean('primary')
+                ->default(false);
+            $table->timestamps();
+        });
+    }
+}

--- a/database/migrations/2021_03_04_100000_create_city_zip_code_table.php
+++ b/database/migrations/2021_03_04_100000_create_city_zip_code_table.php
@@ -11,6 +11,7 @@ class CreateCityZipCodeTable extends Migration
     public function up()
     {
         Schema::create('city_zip_code', function (Blueprint $table) {
+            $table->id();
             $table->foreignIdFor(City::class);
             $table->foreignIdFor(ZipCode::class);
             $table->boolean('primary')

--- a/src/Models/City.php
+++ b/src/Models/City.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Addresses\Models;
+
+use Tipoff\Support\Models\BaseModel;
+use Tipoff\Support\Traits\HasPackageFactory;
+
+class City extends BaseModel
+{
+    use HasPackageFactory;
+
+    protected $casts = [];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::saving(function ($city) {
+            if (empty($city->title)) {
+                throw new \Exception('A city must have a name.');
+            }
+            if (empty($city->slug)) {
+                throw new \Exception('A city must have a slug.');
+            }
+            if (empty($city->state_id)) {
+                throw new \Exception('A city must belong to a state.');
+            }
+        });
+    }
+
+    public function state()
+    {
+        return $this->belongsTo(State::class);
+    }
+}

--- a/src/Models/City.php
+++ b/src/Models/City.php
@@ -39,6 +39,7 @@ class City extends BaseModel
     {
         return $this->belongsToMany(ZipCode::class)
             ->withPivot('primary')
-            ->withTimestamps();;
+            ->withTimestamps();
+        ;
     }
 }

--- a/src/Models/City.php
+++ b/src/Models/City.php
@@ -24,15 +24,7 @@ class City extends BaseModel
             if (empty($city->slug)) {
                 throw new \Exception('A city must have a slug.');
             }
-            if (empty($city->state_id)) {
-                throw new \Exception('A city must belong to a state.');
-            }
         });
-    }
-
-    public function state()
-    {
-        return $this->belongsTo(State::class);
     }
 
     public function zipCodes()

--- a/src/Models/City.php
+++ b/src/Models/City.php
@@ -34,4 +34,11 @@ class City extends BaseModel
     {
         return $this->belongsTo(State::class);
     }
+
+    public function zipCodes()
+    {
+        return $this->belongsToMany(ZipCode::class)
+            ->withPivot('primary')
+            ->withTimestamps();;
+    }
 }

--- a/src/Models/State.php
+++ b/src/Models/State.php
@@ -37,4 +37,9 @@ class State extends BaseModel
     {
         return $this->belongsTo(Country::class);
     }
+
+    public function zipCodes()
+    {
+        return $this->hasMany(ZipCode::class);
+    }
 }

--- a/src/Models/ZipCode.php
+++ b/src/Models/ZipCode.php
@@ -36,4 +36,11 @@ class ZipCode extends BaseModel
     {
         return $this->belongsTo(State::class);
     }
+
+    public function cities()
+    {
+        return $this->belongsToMany(City::class)
+            ->withPivot('primary')
+            ->withTimestamps();
+    }
 }


### PR DESCRIPTION
closes #18 

- added City Model & Migration
- added Pivot table City_Zip_Code, with field _primary_ for city is the primary city for a zip_code
- added _many to many_ relationships in Models _City_ and _Zip Code_

Unsure of how you want to handle secondary options for Zip Code + City 
(quoted in #18)
> ZIP Codes #17 will have primary and multiple secondary options for Cities.