### PR TITLE
Omnia/feature/39 create timezone nova resource

### DIFF
--- a/src/AddressesServiceProvider.php
+++ b/src/AddressesServiceProvider.php
@@ -39,7 +39,9 @@ class AddressesServiceProvider extends TipoffServiceProvider
                 \Tipoff\Addresses\Nova\Address::class,
                 \Tipoff\Addresses\Nova\City::class,
                 \Tipoff\Addresses\Nova\Country::class,
+                \Tipoff\Addresses\Nova\Region::class,
                 \Tipoff\Addresses\Nova\State::class,
+                \Tipoff\Addresses\Nova\Timezone::class,
                 \Tipoff\Addresses\Nova\Zip::class,
             ])
             ->name('addresses')

--- a/src/Nova/Timezone.php
+++ b/src/Nova/Timezone.php
@@ -10,8 +10,8 @@ use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Number;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
-use Tipoff\Support\Nova\BaseResource;
 use Laravel\Nova\Panel;
+use Tipoff\Support\Nova\BaseResource;
 
 class Timezone extends BaseResource
 {

--- a/src/Nova/Timezone.php
+++ b/src/Nova/Timezone.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Addresses\Nova;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Boolean;
+use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\Number;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Tipoff\Support\Nova\BaseResource;
+use Laravel\Nova\Panel;
+
+class Timezone extends BaseResource
+{
+    public static $model = \Tipoff\Addresses\Models\Timezone::class;
+
+    public static $title = 'title';
+
+    public static $search = [
+        'id',
+    ];
+
+    public function fieldsForIndex(NovaRequest $request)
+    {
+        return array_filter([
+            ID::make()->sortable(),
+        ]);
+    }
+
+    public function fields(Request $request)
+    {
+        return array_filter([
+            Text::make('Name')->required()->creationRules('unique:timezones,name'),
+            Text::make('Title')->required()->creationRules('unique:timezones,title'),
+            Text::make('Php')->required()->creationRules('unique:timezones,php'),
+            Boolean::make('Is daylight saving')->required()->default(1),
+            Number::make('Dst')->min(-9999.99)->max(9999.99)->step(0.01)->nullable(),
+            Number::make('Standard')->min(-9999.99)->max(9999.99)->step(0.01)->nullable(),
+
+            new Panel('Data Fields', $this->dataFields()),
+        ]);
+    }
+
+    public function dataFields(): array
+    {
+        return array_merge(
+            parent::dataFields(),
+        );
+    }
+}


### PR DESCRIPTION
closes #39 

- added Nova resource, Timezone
- added Nova resources Region and Timezone to _Addresses Service Provider_

Model Timezone, there are _belongsToMany_ relationships to Locations and Markets  (Package/Locations)
These are not included in the Migration Timezone, so I did not add reference in Nova resource Timezone