### PR TITLE
Add support for copying addresses from one model to another

### DIFF
--- a/src/Traits/HasAddresses.php
+++ b/src/Traits/HasAddresses.php
@@ -62,6 +62,21 @@ trait HasAddresses
         return $this->setAddressByType(get_class($this), $domesticAddress);
     }
 
+    public function copyAddressesToTarget($target, ?\Closure $filter = null): self
+    {
+        $this->addresses
+            ->filter(function (Address $sourceAddress) use ($filter) {
+                return empty($filter) || ($filter)($sourceAddress);
+            })
+            ->each(function (Address $souceAddress) use ($target) {
+                // Create a copy, replacing the addressable with the target before saving
+                $targetAddress = $souceAddress->replicate();
+                $targetAddress->addressable()->associate($target)->save();
+            });
+
+        return $this;
+    }
+
     public function addresses()
     {
         return $this->morphMany(Address::class, 'addressable');

--- a/src/Traits/HasAddresses.php
+++ b/src/Traits/HasAddresses.php
@@ -68,9 +68,9 @@ trait HasAddresses
             ->filter(function (Address $sourceAddress) use ($filter) {
                 return empty($filter) || ($filter)($sourceAddress);
             })
-            ->each(function (Address $souceAddress) use ($target) {
+            ->each(function (Address $sourceAddress) use ($target) {
                 // Create a copy, replacing the addressable with the target before saving
-                $targetAddress = $souceAddress->replicate();
+                $targetAddress = $sourceAddress->replicate();
                 $targetAddress->addressable()->associate($target)->save();
             });
 


### PR DESCRIPTION
The need to copy addresses surfaced in cart->order and now partial voucher redemption.  Pretty sure it will be needed for payments as well, so adding it to the HasAddresses trait.