### PR TITLE
Fix createDomesticAddress for city schema changes

### DIFF
--- a/src/Models/City.php
+++ b/src/Models/City.php
@@ -43,6 +43,11 @@ class City extends BaseModel
         return $query->where('title', '=', trim($title));
     }
 
+    public function scopeByZip(Builder $query, Zip $zip): Builder
+    {
+        return $query->where('state_id', '=', $zip->state_id);
+    }
+
     public function timezone()
     {
         return $this->belongsTo(app('timezone'));

--- a/src/Models/DomesticAddress.php
+++ b/src/Models/DomesticAddress.php
@@ -48,7 +48,10 @@ class DomesticAddress extends BaseModel
     public static function createDomesticAddress(string $line1, ?string $line2, $city, $zip): self
     {
         $zip = ($zip instanceof Zip) ? $zip : Zip::query()->findOrFail(trim($zip));
-        $city = ($city instanceof City) ? $city : City::query()->byTitle($city)->firstOrCreate(['title' => $city]);
+        $city = ($city instanceof City) ? $city : City::query()->byTitle($city)->byZip($zip)->firstOrCreate([
+            'title' => $city,
+            'state_id' => $zip->state_id
+        ]);
 
         /** @var DomesticAddress $domesticAddress */
         $domesticAddress = static::query()->firstOrCreate([

--- a/src/Models/DomesticAddress.php
+++ b/src/Models/DomesticAddress.php
@@ -50,7 +50,7 @@ class DomesticAddress extends BaseModel
         $zip = ($zip instanceof Zip) ? $zip : Zip::query()->findOrFail(trim($zip));
         $city = ($city instanceof City) ? $city : City::query()->byTitle($city)->byZip($zip)->firstOrCreate([
             'title' => $city,
-            'state_id' => $zip->state_id
+            'state_id' => $zip->state_id,
         ]);
 
         /** @var DomesticAddress $domesticAddress */

--- a/tests/Unit/Models/DomesticAddressModelTest.php
+++ b/tests/Unit/Models/DomesticAddressModelTest.php
@@ -25,10 +25,12 @@ class DomesticAddressModelTest extends TestCase
     /** @test */
     public function create_address_valid_city_and_zip()
     {
-        /** @var City $city */
-        $city = City::factory()->create();
         /** @var Zip $zip */
         $zip = Zip::factory()->create();
+        /** @var City $city */
+        $city = City::factory()->create([
+            'state_id' => $zip->state_id,
+        ]);
 
         $address = DomesticAddress::createDomesticAddress('line1', null, $city->title, $zip->code);
         $this->assertEquals('line1', $address->address_line_1);
@@ -38,6 +40,16 @@ class DomesticAddressModelTest extends TestCase
 
         $sameAddress = DomesticAddress::createDomesticAddress('line1', null, $city, $zip);
         $this->assertEquals($address->id, $sameAddress->id);
+    }
+
+    /** @test */
+    public function create_address_unknown_city()
+    {
+        /** @var Zip $zip */
+        $zip = Zip::factory()->create();
+
+        $address = DomesticAddress::createDomesticAddress('line1', null, 'Boston', $zip->code);
+        $this->assertEquals('Boston', $address->city->title);
     }
 
     /** @test */


### PR DESCRIPTION
Not sure why, but a failing test was removed instead of fixed.  This fixes the implementation that was flagged by the failing test and re-adds the test. 