### PR TITLE
Add validation to livewire component #72 #75 [TGER-133]

### DIFF
--- a/resources/views/livewire/domestic-address-search-bar-fields.blade.php
+++ b/resources/views/livewire/domestic-address-search-bar-fields.blade.php
@@ -1,7 +1,10 @@
 <div
-    x-data="{}"
+    x-data="{
+        addressFocused: false
+    }"
     @focus-address-line-2.window="$refs.addressLine2.focus()"
     class="flex justify-between w-full mt-4 text-gray-700 ring-1 ring-gray-300 rounded-md overflow-hidden"
+    x-bind:class="{ 'ring-2 ring-blue-300' : addressFocused }"
 >
     <div class="w-9/12">
         <label class="ml-2 text-xs text-gray-500 font-semibold tracking-widest">
@@ -13,6 +16,8 @@
             type="text"
             readonly="readonly"
             wire:model="addressLine1"
+            x-on:focus="addressFocused = true"
+            x-on:blur="addressFocused = false"
             class="w-full px-2 py-1 focus:outline-none"
             required
         >
@@ -26,6 +31,8 @@
             name="address-line-2"
             type="text"
             x-ref="addressLine2"
+            x-on:focus="addressFocused = true"
+            x-on:blur="addressFocused = false"
             class="w-full px-2 py-1 focus:outline-none"
         >
     </div>

--- a/resources/views/livewire/domestic-address-search-bar-fields.blade.php
+++ b/resources/views/livewire/domestic-address-search-bar-fields.blade.php
@@ -1,7 +1,7 @@
 <div
     x-data="{}"
     @focus-address-line-2.window="$refs.addressLine2.focus()"
-    class="flex justify-between w-full mt-4 text-gray-700 border rounded-md overflow-hidden"
+    class="flex justify-between w-full mt-4 text-gray-700 ring-1 ring-gray-300 rounded-md overflow-hidden"
 >
     <div class="w-9/12">
         <label class="ml-2 text-xs text-gray-500 font-semibold tracking-widest">

--- a/resources/views/livewire/domestic-address-search-bar-fields.blade.php
+++ b/resources/views/livewire/domestic-address-search-bar-fields.blade.php
@@ -7,7 +7,7 @@
     x-bind:class="{ 'ring-2 ring-blue-300' : addressFocused }"
 >
     <div class="w-9/12">
-        <label class="ml-2 text-xs text-gray-500 font-semibold tracking-widest">
+        <label class="ml-2 text-xs text-gray-400 font-semibold tracking-widest">
             Address 1
         </label>
         <input
@@ -23,7 +23,7 @@
         >
     </div>
     <div class="w-3/12 ml-2">
-        <label class="ml-2 text-xs text-gray-500 font-semibold tracking-widest">
+        <label class="ml-2 text-xs text-gray-400 font-semibold tracking-widest">
             Address 2
         </label>
         <input

--- a/resources/views/livewire/domestic-address-search-bar.blade.php
+++ b/resources/views/livewire/domestic-address-search-bar.blade.php
@@ -18,6 +18,7 @@
         x-on:click.away="showResults = false"
         class="w-full px-2 py-1 focus:outline-none"
     >
+    @error('query') <span class="text-xs text-red-500">{{ $message }}</span> @enderror
     <!-- List of results -->
     <div
         id="results-list"

--- a/resources/views/livewire/domestic-address-search-bar.blade.php
+++ b/resources/views/livewire/domestic-address-search-bar.blade.php
@@ -18,7 +18,9 @@
         x-on:click.away="showResults = false"
         class="w-full px-2 py-1 focus:outline-none"
     >
-    @error('query') <span class="text-xs text-red-500">{{ $message }}</span> @enderror
+    @error('query') 
+    <span class="text-xs text-red-500">{{ $message }}</span>
+    @enderror
     <!-- List of results -->
     <div
         id="results-list"

--- a/resources/views/livewire/domestic-address-search-bar.blade.php
+++ b/resources/views/livewire/domestic-address-search-bar.blade.php
@@ -16,10 +16,10 @@
         x-model="selectedResult"
         x-on:click="showResults = true"
         x-on:click.away="showResults = false"
-        class="w-full px-2 py-1 focus:outline-none"
+        class="w-full px-2 py-1 focus:outline-none text-gray-700 ring-1 ring-gray-300 rounded-md overflow-hidden focus:ring-2 focus:ring-blue-300"
     >
     @error('query') 
-    <span class="text-xs text-red-500">{{ $message }}</span>
+    <span class="ml-2 text-xs text-red-500">{{ $message }}</span>
     @enderror
     <!-- List of results -->
     <div

--- a/resources/views/livewire/domestic-address-search-bar.blade.php
+++ b/resources/views/livewire/domestic-address-search-bar.blade.php
@@ -25,7 +25,7 @@
     <div
         id="results-list"
         x-show="showResults"
-        class="absolute z-10 w-full"
+        class="absolute top-9 z-10 w-full"
     >
         @if (!empty($results))
         @foreach ($results as $result)

--- a/src/Http/Livewire/DomesticAddressSearchBar.php
+++ b/src/Http/Livewire/DomesticAddressSearchBar.php
@@ -19,6 +19,14 @@ class DomesticAddressSearchBar extends Component
 
     public $placeDetailsParams;
 
+    protected $rules = [
+        'query' => ['regex:/^\d/'],
+    ];
+
+    protected $messages = [
+        'query.regex' => 'Please enter a street number.',
+    ];
+
     public function mount()
     {
         $sessionToken = (string)Str::uuid();
@@ -58,6 +66,7 @@ class DomesticAddressSearchBar extends Component
     public function updatedQuery()
     {
         if (! empty($this->query)) {
+            $this->validate();
             $resultsCollection = app()->make(PlacesApi::class)->placeAutocomplete($this->query, $this->autocompleteParams);
             $this->results = $resultsCollection['predictions'];
         }


### PR DESCRIPTION
- added styling
- added focus effect on address fields
- added livewire validation on search query _before_ Place Autocomplete API call
    - simple check for address query starts with a digit (addresses like 1A Stillson Street, Atlanta, GA, USA are possible)
    - this stops API from returning partial addresses w/o a street number, and we can store the address directly from Google's API response
    - not sure if street numbers can start with non-digits, P.O. boxes

We can make the Address box smaller, but I think we need to add a custom class to the Tailwind config, to make the text labels smaller than size 1.