### PR TITLE
Update again domestic address javascript component #72 #75 [TGER-140]

### DIFF
--- a/resources/views/domestic-address-search-bar-fields-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-fields-javascript.blade.php
@@ -1,4 +1,5 @@
 <div
+    id="parent-field"
     class="flex justify-between w-full mt-4 text-gray-700 ring-1 ring-gray-300 rounded-md overflow-hidden"
 >
     <div class="w-9/12">
@@ -10,6 +11,8 @@
             name="address-line-1"
             type="text"
             readonly="readonly"
+            onfocus="focusField()"
+            onblur="blurField()"
             class="w-full px-2 py-1 focus:outline-none"
             required
         >
@@ -22,6 +25,8 @@
             id="address-line-2"
             name="address-line-2"
             type="text"
+            onfocus="focusField()"
+            onblur="blurField()"
             class="w-full px-2 py-1 focus:outline-none"
         >
     </div>

--- a/resources/views/domestic-address-search-bar-fields-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-fields-javascript.blade.php
@@ -1,0 +1,52 @@
+<div
+    class="flex justify-between w-full mt-4 text-gray-700 ring-1 ring-gray-300 rounded-md overflow-hidden"
+>
+    <div class="w-9/12">
+        <label class="ml-2 text-xs text-gray-400 font-semibold tracking-widest">
+            Address 1
+        </label>
+        <input
+            id="address-line-1"
+            name="address-line-1"
+            type="text"
+            readonly="readonly"
+            class="w-full px-2 py-1 focus:outline-none"
+            required
+        >
+    </div>
+    <div class="w-3/12 ml-2">
+        <label class="ml-2 text-xs text-gray-400 font-semibold tracking-widest">
+            Address 2
+        </label>
+        <input
+            id="address-line-2"
+            name="address-line-2"
+            type="text"
+            class="w-full px-2 py-1 focus:outline-none"
+        >
+    </div>
+    <div class="">
+        <input
+            id="city"
+            name="city"
+            type="hidden"
+            required
+        >
+    </div>
+    <div class="">
+        <input
+            id="state"
+            name="state"
+            type="hidden"
+            required
+        >
+    </div>
+    <div class="">
+        <input
+            id="zip"
+            name="zip"
+            type="hidden"
+            required
+        >
+    </div>
+</div>

--- a/resources/views/domestic-address-search-bar-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-javascript.blade.php
@@ -82,12 +82,6 @@
 
 @push ('scripts')
 <script type="text/javascript">
-    const inputAddressLine1 = document.getElementById("address-line-1");
-    const inputAddressLine2 = document.getElementById("address-line-2");
-    const inputCity = document.getElementById("city");
-    const inputState = document.getElementById("state");
-    const inputZip = document.getElementById("zip");
-    
     const options = {
         componentRestrictions: { 
             country: "us",
@@ -116,7 +110,6 @@
         let city = "";
         let state = "";
         let zip = "";
-
         // Get each component of the address from the place details,
         // and then fill-in the corresponding field on the form.
         // place.address_components are google.maps.GeocoderAddressComponent objects
@@ -153,14 +146,14 @@
                 //     break;
             }
         }
-        inputAddressLine1.value = addressLine1;
-        inputCity.value = city;
-        inputState.value = state;
-        inputZip.value = zip;
+        document.getElementById("address-line-1").value = addressLine1;
+        document.getElementById("city").value = city;
+        document.getElementById("state").value = state;
+        document.getElementById("zip").value = zip;
         // After filling the form with address components from the Autocomplete
         // prediction, set cursor focus on the second address line to encourage
         // entry of subpremise information such as apartment, unit, or floor number.
-        inputAddressLine2.focus();
+        document.getElementById("address-line-2").focus();
     }
 </script>
 <script src="https://maps.googleapis.com/maps/api/js?key={{ config('google-api.places.key') }}&libraries=places&callback=initAutocomplete" async defer type="text/javascript"></script>

--- a/resources/views/domestic-address-search-bar-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-javascript.blade.php
@@ -81,14 +81,12 @@
 </div>
 
 @push ('scripts')
-<script src="https://maps.googleapis.com/maps/api/js?key={{ config('google-api.places.key') }}&libraries=places&callback=initAutocomplete" async defer>
+<script type="text/javascript">
     const inputAddressLine1 = document.getElementById("address-line-1");
     const inputAddressLine2 = document.getElementById("address-line-2");
     const inputCity = document.getElementById("city");
     const inputState = document.getElementById("state");
     const inputZip = document.getElementById("zip");
-    
-    const inputAutocomplete = document.getElementById("autocomplete");
     
     const options = {
         componentRestrictions: { 
@@ -106,11 +104,10 @@
 
     let autocomplete;
     function initAutocomplete() {
-        autocomplete = new google.maps.places.Autocomplete(inputAutocomplete, options);
-    }    
-
-    // event 'place_changed' fires when User selects an address from dropdown list
-    autocomplete.addListener("place_changed", addressSelected);
+        autocomplete = new google.maps.places.Autocomplete(document.getElementById("autocomplete"), options);
+        // event 'place_changed' fires when User selects an address from dropdown list
+        autocomplete.addListener("place_changed", addressSelected);
+    }
 
     function addressSelected() {
         // Get the place details from the autocomplete object.
@@ -166,4 +163,5 @@
         inputAddressLine2.focus();
     }
 </script>
+<script src="https://maps.googleapis.com/maps/api/js?key={{ config('google-api.places.key') }}&libraries=places&callback=initAutocomplete" async defer type="text/javascript"></script>
 @endpush

--- a/resources/views/domestic-address-search-bar-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-javascript.blade.php
@@ -82,6 +82,16 @@
         // entry of subpremise information such as apartment, unit, or floor number.
         document.getElementById("address-line-2").focus();
     }
+
+    function focusField() {
+        document.getElementById("parent-field").classList.add("ring-2");
+        document.getElementById("parent-field").classList.add("ring-blue-300");
+    }
+
+    function blurField() {
+        document.getElementById("parent-field").classList.remove("ring-2");
+        document.getElementById("parent-field").classList.remove("ring-blue-300");
+    }
 </script>
 <script src="https://maps.googleapis.com/maps/api/js?key={{ config('google-api.places.key') }}&libraries=places&callback=initAutocomplete" async defer type="text/javascript"></script>
 @endpush

--- a/resources/views/domestic-address-search-bar-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-javascript.blade.php
@@ -1,83 +1,10 @@
-<div class="w-3/4">
+<div class="w-full">
     <input
         id="autocomplete"
         type="text"
-        class="w-full px-2 py-1"
+        placeholder="Enter your address"
+        class="w-full px-2 py-1 focus:outline-none text-gray-700 ring-1 ring-gray-300 rounded-md overflow-hidden focus:ring-2 focus:ring-blue-300"
     >
-    <form 
-        method="POST"
-        action=""
-        class="w-full"
-    >
-        @csrf
-        <div class="flex justify-between w-full mt-4 text-gray-700">
-            <div class="w-4/12">
-                <label class="ml-2 text-xs text-gray-500 font-semibold tracking-widest">
-                    Address 1
-                </label>
-                <input
-                    id="address-line-1"
-                    name="address-line-1"
-                    type="text"
-                    readonly="readonly"
-                    class="w-full px-2 py-1 bg-yellow-50"
-                >
-            </div>
-            <div class="w-4/12 ml-2">
-                <label class="ml-2 text-xs text-gray-500 font-semibold tracking-widest">
-                    Address 2
-                </label>
-                <input
-                    id="address-line-2"
-                    name="address-line-2"
-                    type="text"
-                    class="w-full px-2 py-1"
-                >
-            </div>
-            <div class="w-2/12 ml-2">
-                <label class="ml-2 text-xs text-gray-500 font-semibold tracking-widest">
-                    City
-                </label>
-                <input
-                    id="city"
-                    name="city"
-                    type="text"
-                    readonly="readonly"
-                    class="w-full px-2 py-1 bg-yellow-50"
-                >
-            </div>
-            <div class="w-1/12 ml-2">
-                <label class="ml-2 text-xs text-gray-500 font-semibold tracking-widest">
-                    State
-                </label>
-                <input
-                    id="state"
-                    name="state"
-                    type="text"
-                    readonly="readonly"
-                    class="w-full px-2 py-1 bg-yellow-50"
-                >
-            </div>
-            <div class="w-1/12 ml-2">
-                <label class="ml-2 text-xs text-gray-500 font-semibold tracking-widest">
-                    Zip
-                </label>
-                <input
-                    id="zip"
-                    name="zip"
-                    type="text"
-                    readonly="readonly"
-                    class="w-full px-2 py-1 bg-yellow-50"
-                >
-            </div>
-        </div>
-        <button 
-            type="submit"
-            class="mt-2 px-2 py-1 bg-white text-green-500 border-2 border-green-400 rounded-md"
-        >
-            Submit
-        </button>
-    </form>
 </div>
 
 @push ('scripts')


### PR DESCRIPTION
- moved script logic into separate script from async google api script
- separated component into 2 parts for reusability
- added frontend focus effects

to use
```html
<div class="flex justify-center">
    <div class="w-1/2">
        @include ('addresses::domestic-address-search-bar-javascript')
        <form 
            method="POST"
            action="{{ route('submit-form') }}" 
        >
            @csrf
            @include ('addresses::domestic-address-search-bar-fields-javascript')
            <button type="submit">Submit</button>
        </form>
    </div>
</div>
```

![image](https://user-images.githubusercontent.com/62731054/115309668-967ece80-a13a-11eb-8100-cd5f71c5345a.png)
![image](https://user-images.githubusercontent.com/62731054/115309911-efe6fd80-a13a-11eb-8a6a-ac9ef9e1b8bd.png)

The biggest problem is that, like the Livewire component, Google returns partial addresses.  After researching, many users are having this problem without a fix.  Even though they claim when types=address, "Generally, you use this request when you know the user will be looking for a _fully specified address_."
![image](https://user-images.githubusercontent.com/62731054/115310579-02ae0200-a13c-11eb-915e-4a22d2d4374b.png)
![image](https://user-images.githubusercontent.com/62731054/115310624-178a9580-a13c-11eb-89df-75c6240809dc.png)

We should validate on the frontend, that query starts with a number, like I did with the Livewire version.