### PR TITLE
Use Google Service class instead of Widget class for domestic address javascript component #72 #75 [TGER-140]

### DIFF
--- a/resources/views/domestic-address-search-bar-fields-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-fields-javascript.blade.php
@@ -1,6 +1,6 @@
 <div
     id="parent-field"
-    class="flex justify-between w-full mt-4 text-gray-700 ring-1 ring-gray-300 rounded-md overflow-hidden"
+    class="flex justify-between w-full text-gray-700 ring-1 ring-gray-300 rounded-md overflow-hidden"
 >
     <div class="w-9/12">
         <label class="ml-2 text-xs text-gray-400 font-semibold tracking-widest">

--- a/resources/views/domestic-address-search-bar-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-javascript.blade.php
@@ -92,6 +92,7 @@
         };
     }
 
+    const debounceDelay = 400;
     const getPredictions = debounce(function (query) {
         let startsWithStreetNumber = /^\d/;
         let errorMsg = "Please enter a street number.";
@@ -104,7 +105,7 @@
             autocompleteParams.input = query;
             autocompleteService.getPlacePredictions(autocompleteParams, populatePredictions);
         }
-    }, 1000, false);
+    }, debounceDelay, false);
 
     function populateFields(placeDetails, status) {
         let addressLine1 = "";

--- a/resources/views/domestic-address-search-bar-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-javascript.blade.php
@@ -1,4 +1,4 @@
-<div class="w-full">
+<div class="relative">
     <input
         id="search-bar"
         type="text"
@@ -9,12 +9,12 @@
         class="w-full px-2 py-1 focus:outline-none text-gray-700 ring-1 ring-gray-300 rounded-md overflow-hidden focus:ring-2 focus:ring-blue-300"
     >
     <span id="error-msg" class="ml-2 text-xs text-red-500"></span>
-    <div id="attributions"></div>
     <div
         id="results-list"
         class="absolute top-9 z-10 w-full"
     >
     </div>
+    <div id="attributions"></div>
 </div>
 
 @push ('scripts')

--- a/resources/views/domestic-address-search-bar-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-javascript.blade.php
@@ -2,6 +2,8 @@
     <input
         type="text"
         placeholder="Enter your address"
+        onfocus="showPredictions()"
+        onblur="hidePredictions()"
         oninput="getPredictions(this.value)"
         class="w-full px-2 py-1 focus:outline-none text-gray-700 ring-1 ring-gray-300 rounded-md overflow-hidden focus:ring-2 focus:ring-blue-300"
     >
@@ -54,7 +56,7 @@
         resetSessionToken();
     }
 
-    function showPredictions(predictions, status) {
+    function populatePredictions(predictions, status) {
         // clear results in list
         document.getElementById("results-list").innerHTML = "";
         // show results in list
@@ -73,7 +75,7 @@
 
     function getPredictions(query) {
         autocompleteParams.input = query;
-        autocompleteService.getPlacePredictions(autocompleteParams, showPredictions);
+        autocompleteService.getPlacePredictions(autocompleteParams, populatePredictions);
     }
 
     function populateFields(placeDetails, status) {
@@ -141,6 +143,14 @@
     function blurField() {
         document.getElementById("parent-field").classList.remove("ring-2");
         document.getElementById("parent-field").classList.remove("ring-blue-300");
+    }
+
+    function showPredictions() {
+        document.getElementById("results-list").classList.remove("invisible");
+    }
+
+    function hidePredictions() {
+        document.getElementById("results-list").classList.add("invisible");
     }
 </script>
 <script src="https://maps.googleapis.com/maps/api/js?key={{ config('google-api.places.key') }}&libraries=places&callback=initAutocomplete" async defer type="text/javascript"></script>

--- a/resources/views/domestic-address-search-bar-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-javascript.blade.php
@@ -1,5 +1,6 @@
 <div class="w-full">
     <input
+        id="search-bar"
         type="text"
         placeholder="Enter your address"
         onfocus="showPredictions()"
@@ -66,6 +67,7 @@
             result.innerText = prediction.description;
             result.onmousedown = function () {
                 hidePredictions();
+                document.getElementById("search-bar").value = prediction.description;
                 addressSelected(prediction.place_id);
             }
             document.getElementById("results-list").appendChild(result);

--- a/resources/views/domestic-address-search-bar-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-javascript.blade.php
@@ -75,17 +75,34 @@
         });
     }
 
-    function getPredictions(query) {
+    function debounce(func, wait, immediate) {
+        var timeout;
+        return function() {
+            var context = this, args = arguments;
+            var later = function() {
+                timeout = null;
+                if (!immediate) func.apply(context, args);
+            };
+            var callNow = immediate && !timeout;
+            clearTimeout(timeout);
+            timeout = setTimeout(later, wait);
+            if (callNow) func.apply(context, args);
+        };
+    }
+
+    const getPredictions = debounce(function (query) {
         let startsWithStreetNumber = /^\d/;
         let errorMsg = "Please enter a street number.";
         if (!startsWithStreetNumber.test(query) ) {
+            hidePredictions();
             document.getElementById("error-msg").innerText = errorMsg;
         } else {
+            showPredictions();
             document.getElementById("error-msg").innerText = "";
             autocompleteParams.input = query;
             autocompleteService.getPlacePredictions(autocompleteParams, populatePredictions);
         }
-    }
+    }, 1000, false);
 
     function populateFields(placeDetails, status) {
         let addressLine1 = "";

--- a/resources/views/domestic-address-search-bar-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-javascript.blade.php
@@ -62,17 +62,19 @@
         // clear results in list
         document.getElementById("results-list").innerHTML = "";
         // show results in list
-        predictions.forEach(prediction => {
-            const result = document.createElement("div");
-            result.className = "block w-full px-2 py-1 text-left bg-white cursor-default hover:bg-gray-50";
-            result.innerText = prediction.description;
-            result.onmousedown = function () {
-                hidePredictions();
-                document.getElementById("search-bar").value = prediction.description;
-                addressSelected(prediction.place_id);
-            }
-            document.getElementById("results-list").appendChild(result);
-        });
+        if (status === 'OK') {
+            predictions.forEach(prediction => {
+                const result = document.createElement("div");
+                result.className = "block w-full px-2 py-1 text-left bg-white cursor-default hover:bg-gray-50";
+                result.innerText = prediction.description;
+                result.onmousedown = function () {
+                    hidePredictions();
+                    document.getElementById("search-bar").value = prediction.description;
+                    addressSelected(prediction.place_id);
+                }
+                document.getElementById("results-list").appendChild(result);
+            });
+        }
     }
 
     function debounce(func, wait, immediate) {

--- a/resources/views/domestic-address-search-bar-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-javascript.blade.php
@@ -3,11 +3,12 @@
         id="search-bar"
         type="text"
         placeholder="Enter your address"
+        oninput="getPredictions(this.value)"
         onfocus="showPredictions()"
         onblur="hidePredictions()"
-        oninput="getPredictions(this.value)"
         class="w-full px-2 py-1 focus:outline-none text-gray-700 ring-1 ring-gray-300 rounded-md overflow-hidden focus:ring-2 focus:ring-blue-300"
     >
+    <span id="error-msg" class="ml-2 text-xs text-red-500"></span>
     <div id="attributions"></div>
     <div
         id="results-list"
@@ -75,8 +76,15 @@
     }
 
     function getPredictions(query) {
-        autocompleteParams.input = query;
-        autocompleteService.getPlacePredictions(autocompleteParams, populatePredictions);
+        let startsWithStreetNumber = /^\d/;
+        let errorMsg = "Please enter a street number.";
+        if (!startsWithStreetNumber.test(query) ) {
+            document.getElementById("error-msg").innerText = errorMsg;
+        } else {
+            document.getElementById("error-msg").innerText = "";
+            autocompleteParams.input = query;
+            autocompleteService.getPlacePredictions(autocompleteParams, populatePredictions);
+        }
     }
 
     function populateFields(placeDetails, status) {

--- a/resources/views/domestic-address-search-bar-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-javascript.blade.php
@@ -62,7 +62,7 @@
         // clear results in list
         document.getElementById("results-list").innerHTML = "";
         // show results in list
-        if (status === 'OK') {
+        if (status === "OK") {
             predictions.forEach(prediction => {
                 const result = document.createElement("div");
                 result.className = "block w-full px-2 py-1 text-left bg-white cursor-default hover:bg-gray-50";

--- a/resources/views/domestic-address-search-bar-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-javascript.blade.php
@@ -70,7 +70,6 @@
             }
             document.getElementById("results-list").appendChild(result);
         });
-        // document.getElementById("results-list")
     }
 
     function getPredictions(query) {

--- a/resources/views/domestic-address-search-bar-javascript.blade.php
+++ b/resources/views/domestic-address-search-bar-javascript.blade.php
@@ -64,8 +64,8 @@
             const result = document.createElement("div");
             result.className = "block w-full px-2 py-1 text-left bg-white cursor-default hover:bg-gray-50";
             result.innerText = prediction.description;
-            result.onclick = function () {
-                document.getElementById("results-list").classList.add("invisible");
+            result.onmousedown = function () {
+                hidePredictions();
                 addressSelected(prediction.place_id);
             }
             document.getElementById("results-list").appendChild(result);

--- a/resources/views/livewire/domestic-address-search-bar-fields.blade.php
+++ b/resources/views/livewire/domestic-address-search-bar-fields.blade.php
@@ -3,7 +3,7 @@
         addressFocused: false
     }"
     @focus-address-line-2.window="$refs.addressLine2.focus()"
-    class="flex justify-between w-full mt-4 text-gray-700 ring-1 ring-gray-300 rounded-md overflow-hidden"
+    class="flex justify-between w-full text-gray-700 ring-1 ring-gray-300 rounded-md overflow-hidden"
     x-bind:class="{ 'ring-2 ring-blue-300' : addressFocused }"
 >
     <div class="w-9/12">


### PR DESCRIPTION
- change component to use Google Service classes instead of Widget class; allows for finer tuning (validation, debouncing)
- added debouncing on user input, to decrease autocomplete API calls & costs
- added validation
  - query must start with a number; else API returns partial addresses w/o street number & zip

![image](https://user-images.githubusercontent.com/62731054/115590652-37869a00-a29f-11eb-9a40-7508199d8630.png)
![image](https://user-images.githubusercontent.com/62731054/115590681-41100200-a29f-11eb-90e4-2d6ec9cdfe9e.png)
![image](https://user-images.githubusercontent.com/62731054/115590741-508f4b00-a29f-11eb-8556-6968b3c3b801.png)

