### PR TITLE
#73 Separate Phone livewire component from form html element

### DIFF
--- a/resources/views/livewire/phone-number-field.blade.php
+++ b/resources/views/livewire/phone-number-field.blade.php
@@ -1,10 +1,7 @@
 <div class="container">
-    <form wire:ignore id="phone-number" onsubmit="savePhoneNumber(event)">
-        <p>Enter your phone number:</p>
+    <p>Enter your phone number:</p>
 
-        <input id="phone" type="tel" name="phone"/>
-        <input type="submit" class="btn" value="Submit"/>
-    </form>
+    <input id="phone" type="tel" name="phone"/>
 
     <div id="success-message" style="display:none"></div>
 </div>
@@ -22,18 +19,18 @@
             utilsScript: 'https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.12/js/utils.js',
         });
 
-        function savePhoneNumber(event) {
-            event.preventDefault();
+        // function savePhoneNumber(event) {
+        //     event.preventDefault();
 
-            const phoneNumber = phoneInput.getNumber();
+        //     const phoneNumber = phoneInput.getNumber();
 
-            if (!phoneNumber) {
-                alert('Phone number is empty');
-            }
-            else {
-                @this.call('savePhoneNumber', phoneNumber);
-            }
-        }
+        //     if (!phoneNumber) {
+        //         alert('Phone number is empty');
+        //     }
+        //     else {
+        //         @this.call('savePhoneNumber', phoneNumber);
+        //     }
+        // }
 
         function getIp(callback) {
             fetch('https://ipinfo.io/json?token=0033205e80e0d9', {headers: {'Accept': 'application/json'}})

--- a/src/Actions/SaveDomesticAddressAction.php
+++ b/src/Actions/SaveDomesticAddressAction.php
@@ -19,7 +19,7 @@ class SaveDomesticAddressAction
         return optional($city)->domesticAddresses()->firstOrCreate([
             'address_line_1' => $keys['address-line-1'],
             'address_line_2' => $keys['address-line-2'],
-            'zip_code' => $keys['zip'],
+            'zip_code' => $zip->code,
         ]);
     }
 }

--- a/src/Actions/SaveDomesticAddressAction.php
+++ b/src/Actions/SaveDomesticAddressAction.php
@@ -1,0 +1,25 @@
+<?php namespace Tipoff\Addresses\Actions;
+
+use Tipoff\Addresses\Models\City;
+use Tipoff\Addresses\Models\Zip;
+
+class SaveDomesticAddressAction
+{
+    public function execute(array $keys)
+    {
+        $city = City::where('title', $keys['city'])->first();
+        if (! $city) {
+            throw new \Exception('City does not exist.');
+        }
+        $zip = Zip::where('code', $keys['zip'])->first();
+        if (! $zip) {
+            throw new \Exception('Zip code does not exist.');
+        }
+
+        return optional($city)->domesticAddresses()->firstOrCreate([
+            'address_line_1' => $keys['address-line-1'],
+            'address_line_2' => $keys['address-line-2'],
+            'zip_code' => $keys['zip'],
+        ]);
+    }
+}

--- a/src/Actions/SavePhoneNumberAction.php
+++ b/src/Actions/SavePhoneNumberAction.php
@@ -28,7 +28,7 @@ class SavePhoneNumberAction
         $countryCallingCode = CountryCallingcode::where('code', $parsedPhoneNumber->getCountryCode())->first();
 
         return optional($countryCallingCode)->phones()->firstOrCreate([
-            'full_number' => $phoneNumber,
+            'full_number' => $countryCallingCode->code . $phoneNumber,
             'phone_area_code' => $this->getAreaCode($parsedPhoneNumber->getNationalNumber()), // This only work for US area code.
         ]);
     }

--- a/src/Actions/SavePhoneNumberAction.php
+++ b/src/Actions/SavePhoneNumberAction.php
@@ -2,7 +2,6 @@
 
 use libphonenumber\PhoneNumberUtil;
 use Tipoff\Addresses\Models\CountryCallingcode;
-use Tipoff\Addresses\Models\Phone;
 use Tipoff\Addresses\Models\PhoneArea;
 
 class SavePhoneNumberAction

--- a/src/Actions/SavePhoneNumberAction.php
+++ b/src/Actions/SavePhoneNumberAction.php
@@ -2,6 +2,8 @@
 
 use libphonenumber\PhoneNumberUtil;
 use Tipoff\Addresses\Models\CountryCallingcode;
+use Tipoff\Addresses\Models\Phone;
+use Tipoff\Addresses\Models\PhoneArea;
 
 class SavePhoneNumberAction
 {
@@ -15,21 +17,24 @@ class SavePhoneNumberAction
         $phoneUtil = PhoneNumberUtil::getInstance();
 
         $parsedPhoneNumber = $phoneUtil->parse($phoneNumber, 'US');
-
+        $parsedCountryCallingcode = $parsedPhoneNumber->getCountryCode();
         /**
          * Only save US phone number.
          * https://github.com/tipoff/addresses/issues/73
          */
-        if ($parsedPhoneNumber->getCountryCode() !== 1) {
+        if ($parsedCountryCallingcode !== 1) {
             throw new \Exception('Please enter an US phone number!');
         }
+        $countryCallingcode = CountryCallingcode::where('code', $parsedCountryCallingcode)->first();
+        $parsedAreaCode = $this->getAreaCode($parsedPhoneNumber->getNationalNumber());
+        $phoneArea = PhoneArea::find($parsedAreaCode);
+        if (! $phoneArea) {
+            throw new \Exception('Please enter a valid US area code.');
+        }
 
-        /** @var CountryCallingcode $countryCallingCode */
-        $countryCallingCode = CountryCallingcode::where('code', $parsedPhoneNumber->getCountryCode())->first();
-
-        return optional($countryCallingCode)->phones()->firstOrCreate([
-            'full_number' => $countryCallingCode->code . $phoneNumber,
-            'phone_area_code' => $this->getAreaCode($parsedPhoneNumber->getNationalNumber()), // This only work for US area code.
+        return optional($countryCallingcode)->phones()->firstOrCreate([
+            'full_number' => $countryCallingcode->code . $phoneNumber,
+            'phone_area_code' => $phoneArea->code, // This only work for US area code.
         ]);
     }
 

--- a/src/Actions/SavePhoneNumberAction.php
+++ b/src/Actions/SavePhoneNumberAction.php
@@ -33,7 +33,7 @@ class SavePhoneNumberAction
 
         return optional($countryCallingcode)->phones()->firstOrCreate([
             'full_number' => $countryCallingcode->code . $phoneNumber,
-            'phone_area_code' => $phoneArea->code, // This only work for US area code.
+            'phone_area_code' => $parsedAreaCode, // This only work for US area code.
         ]);
     }
 

--- a/src/Models/PhoneArea.php
+++ b/src/Models/PhoneArea.php
@@ -36,6 +36,6 @@ class PhoneArea extends BaseModel
 
     public function phones()
     {
-        return $this->hasMany(app('phone'), 'phone_id', 'phone_area_code');
+        return $this->hasMany(app('phone'), 'phone_area_code', 'code');
     }
 }


### PR DESCRIPTION
#73 

- remove Phone component from html form element, allows reusability in other forms
- add Country Callingcode to Phone.fullnumber attribute
- fix PhoneArea model, phones relationship
- add SaveDomesticAddressAction allowing easier user experience

View
```
<div class="flex flex-col">
    <div class="w-1/2 my-4">
        @livewire('addresses::domestic-address-search-bar')
    </div>
    <form 
        method="POST"
        action="{{ route('submit-form') }}" 
        class="w-1/2 my-4"
    >
        @csrf
        @livewire('addresses::domestic-address-search-bar-fields')
        @livewire('addresses::get-phone')
        <button class="mt-4 px-2 py-1 ring-1 ring-gray-400 rounded-md text-gray-400" type="submit">Submit</button>
    </form>
</div>
```
Controller
```
public function store(Request $request)
{
    (new SavePhoneNumberAction)->execute($request->input('phone'));
    (new SaveDomesticAddressAction)->execute($request->all());
}
```